### PR TITLE
Suffix search

### DIFF
--- a/_algolia.yml
+++ b/_algolia.yml
@@ -24,6 +24,7 @@ algolia:
   settings:
     attributesToIndex:
       - unordered(title)
+      - unordered(alt_title)
       - latin
       - unordered(synonyms)
     attributesForFaceting:

--- a/_species/blaskjell.md
+++ b/_species/blaskjell.md
@@ -1,5 +1,5 @@
 ---
-title: Blåskjell
+title: Blå&shy;skjell
 image:
   file: "/uploads/blaskjell.jpg"
   caption: 'Foto: Alf Børjesson / Eksportutvalget for fisk'

--- a/_species/blaskjell.md
+++ b/_species/blaskjell.md
@@ -1,5 +1,6 @@
 ---
-title: Blå&shy;skjell
+title: Blåskjell
+alt_title: Blå&shy;skjell
 image:
   file: "/uploads/blaskjell.jpg"
   caption: 'Foto: Alf Børjesson / Eksportutvalget for fisk'

--- a/_species/hai.md
+++ b/_species/hai.md
@@ -1,7 +1,9 @@
 ---
 title: Hai
 ranking: Red
-synonyms: Håbrann, Pigghå
+synonyms: 
+- Håbrann
+- Pigghå
 slogan:
   content: Ta dei du kan sjå, dei andre let du stå… slik som for eksempel pigghå.
     Men om han skulle bite på så lat han gå, for der er så stekje få.

--- a/_species/havabbor.md
+++ b/_species/havabbor.md
@@ -1,5 +1,6 @@
 ---
 title: Havabbor
+alt_title: Hav&shy;abbor
 latin: Dicentrarchus labrax
 ranking: Orange
 labels:

--- a/_species/hjerteskjell.md
+++ b/_species/hjerteskjell.md
@@ -1,5 +1,6 @@
 ---
-title: Hjerte&shy;skjell
+title: Hjerteskjell
+alt_title: Hjerte&shy;skjell
 image:
   file: "/uploads/hjerteskjell.jpg"
   caption: 'Foto: Eksportutvalget for fisk'

--- a/_species/hjerteskjell.md
+++ b/_species/hjerteskjell.md
@@ -1,5 +1,5 @@
 ---
-title: Hjerteskjell
+title: Hjerte&shy;skjell
 image:
   file: "/uploads/hjerteskjell.jpg"
   caption: 'Foto: Eksportutvalget for fisk'

--- a/_species/hyse.md
+++ b/_species/hyse.md
@@ -8,7 +8,9 @@ ranking: Green
 labels:
 - KRAV
 - MSC
-synonyms: Kolje, Torskefisk
+synonyms: 
+  - Kolje
+  - Torskefisk
 ---
 
 Hyse er en torskefisk som finnes langs hele kysten nord for Stad, i Barentshavet og i Nordsjøen/ Skagerrak.

--- a/_species/kamskjell.md
+++ b/_species/kamskjell.md
@@ -1,5 +1,5 @@
 ---
-title: Kamskjell
+title: Kam&shy;skjell
 image:
   file: "/uploads/kamskjell.jpg"
   caption: 'Foto: Eksportutvalget for fisk'

--- a/_species/kamskjell.md
+++ b/_species/kamskjell.md
@@ -1,5 +1,6 @@
 ---
-title: Kam&shy;skjell
+title: Kamskjell
+alt_title: Kam&shy;skjell
 image:
   file: "/uploads/kamskjell.jpg"
   caption: 'Foto: Eksportutvalget for fisk'

--- a/_species/kongekrabbe.md
+++ b/_species/kongekrabbe.md
@@ -1,5 +1,5 @@
 ---
-title: Kongekrabbe
+title: Konge&shy;krabbe
 image:
   file: "/uploads/kongekrabbe.jpg"
   caption: 'Foto: Eiliv Leren / Eksportutvalget for fisk'

--- a/_species/kongekrabbe.md
+++ b/_species/kongekrabbe.md
@@ -1,5 +1,6 @@
 ---
-title: Konge&shy;krabbe
+title: Kongekrabbe
+alt_title: Konge&shy;krabbe
 image:
   file: "/uploads/kongekrabbe.jpg"
   caption: 'Foto: Eiliv Leren / Eksportutvalget for fisk'

--- a/_species/kysttorsk.md
+++ b/_species/kysttorsk.md
@@ -1,5 +1,6 @@
 ---
-title: Kyst&shy;torsk
+title: Kysttorsk
+alt_title: Kyst&shy;torsk
 image:
   file: "/uploads/torsk.jpg"
   caption: 'Foto: Lauritzen og Westhammer / Eksportutvalget for fisk'

--- a/_species/kysttorsk.md
+++ b/_species/kysttorsk.md
@@ -1,5 +1,5 @@
 ---
-title: Kysttorsk
+title: Kyst&shy;torsk
 image:
   file: "/uploads/torsk.jpg"
   caption: 'Foto: Lauritzen og Westhammer / Eksportutvalget for fisk'
@@ -9,8 +9,6 @@ sources:
 - Artsdatabanken
 - Havforskningsinstituttet
 - WWF
-synonyms:
-- Torskefisk
 ---
 
 Langs kysten vår finnes flere bestander av kysttorsk, men dessverre er mange av bestandene i dårlig forfatning. Det er ikke etablert referansepunkter for kysttorsk fordi fangststatistikken er svært usikker. Usikkerheten kommer delvis av at mengden uregistrert fangst foretatt av fritids- og turistfiskere er uvisst. ICES mener bestanden viser tegn på redusert reproduksjonsevne, og sier at den ikke blir høstet bærekraftig. I Skagerrak er situasjonen spesielt ille. Kysttorsk er derfor ikke et bærekraftig valg.

--- a/_species/rodspette.md
+++ b/_species/rodspette.md
@@ -1,5 +1,6 @@
 ---
 title: Rødspette
+alt_title: Rød&shy;spette
 image:
   file: "/uploads/rodspette.jpg"
   caption: 'Foto: Yvonne Holth / Eksportutvalget for fisk'

--- a/_species/taskekrabbe.md
+++ b/_species/taskekrabbe.md
@@ -1,5 +1,6 @@
 ---
-title: Taske&shy;krabbe
+title: Taskekrabbe
+alt_title: Taske&shy;krabbe
 image:
   file: "/uploads/krabbe.jpg"
   caption: 'Foto: Petter Berg / Eksportutvalget for fisk'

--- a/_species/taskekrabbe.md
+++ b/_species/taskekrabbe.md
@@ -1,5 +1,5 @@
 ---
-title: Taskekrabbe
+title: Taske&shy;krabbe
 image:
   file: "/uploads/krabbe.jpg"
   caption: 'Foto: Petter Berg / Eksportutvalget for fisk'

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -93,6 +93,9 @@
     var client = $.algolia.Client('QRAL2FHS60', '58abef0b64a591c5efda8bbe11d281cd');
     // Replace the following value by the name of the index you want to query.
     var index = client.initIndex('napp');
+    if (location.hostname === 'localhost') {
+     index = client.initIndex('napp_local');
+    }
 
     $('#napp-search .napp-search-clear').click(function() {
       $inputfield.val('').trigger('keyup');

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -27,6 +27,8 @@
 
     if(hit._highlightResult.title && hit._highlightResult.title.matchLevel !== 'none') {
       title = hit._highlightResult.title.value;
+    } else if(hit._highlightResult.alt_title && hit._highlightResult.alt_title.matchLevel !== 'none') {
+      title = hit._highlightResult.alt_title.value;
     }
 
     if(hit._highlightResult.synonyms) {


### PR DESCRIPTION
Algolia does not support suffix search, so adding &shy; between species titles makes it seem like two words.
